### PR TITLE
Allow relative paths by using "hasbin" to check for executable

### DIFF
--- a/lib/atom-isort.coffee
+++ b/lib/atom-isort.coffee
@@ -1,6 +1,7 @@
 fs = require 'fs-plus'
 $ = require 'jquery'
 process = require 'child_process'
+hasbin = require 'hasbin'
 
 module.exports =
 class AtomIsort
@@ -35,7 +36,7 @@ class AtomIsort
       return
 
     isortPath = fs.normalize atom.config.get 'atom-isort.isortPath'
-    if not fs.existsSync isortPath
+    if not fs.existsSync(isortPath) and not hasbin.sync(isortPath)
       @updateStatusbarText 'unable to open ' + isortPath, false
       return
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     }
   },
   "dependencies": {
+    "hasbin": "^1",
     "atom-space-pen-views": "^2.2.0",
     "fs-plus": "^2.8.1",
     "jquery": "^3"


### PR DESCRIPTION
Hi

I use Virtual Environments a lot in python, and having atom use isort from the active virtualenv can be done by just executing from PATH using relative paths.

I use hasbin node package to detect if the bin is accesible or not.