### PR TITLE
Pass current project root as cwd

### DIFF
--- a/lib/atom-isort.coffee
+++ b/lib/atom-isort.coffee
@@ -72,7 +72,9 @@ class AtomIsort
     proc.stdout.on 'end', (chunk) ->
       output.join()
     proc.on 'exit', (exit_code, signal) =>
-      if exit_code != 0
+      if exit_code == 127
+        @updateStatusbarText '?', false
+      else if exit_code != 0
         @updateStatusbarText 'x', false
       else
         @updateStatusbarText '√', true

--- a/lib/atom-isort.coffee
+++ b/lib/atom-isort.coffee
@@ -20,6 +20,9 @@ class AtomIsort
   getFilePath: ->
     return atom.workspace.getActiveTextEditor().getPath()
 
+  getFileDir: ->
+    return atom.project.relativizePath(@getFilePath())[0]
+
   checkImports: (editor = null) ->
     @runIsort 'check', editor
 
@@ -57,10 +60,11 @@ class AtomIsort
     else
       return
     params = params.concat [@getFilePath()]
+    options = {cwd: @getFileDir()}
 
     process = require 'child_process'
 
-    proc = process.spawn isortPath, params
+    proc = process.spawn isortPath, params, options
     output = []
     proc.stdout.setEncoding 'utf8'
     proc.stdout.on 'data', (chunk) ->


### PR DESCRIPTION
When using pyenv to manage python versions, it is important to invoke programs with the proper working directory of the project in which one is working. If not done so, shims will return error code 127, which means that it couldn't find the correct isort to use.

## This is the current behaviour when using pyenv:
**With isort not installed (ok)**
- Reports correct error (not found)

**With isort installed on different python version (wrong)**
- Finds the bin, but shim returns error 127
- Always shows "x"

**With isort installed on project's python version (wrong)**
- Finds the bin, but shim returns error 127
- Always shows "x"

## Expected behaviour:

**With isort installed on different python version**
- Finds the bin, and returns an error different to "x"

**With isort installed on project's python version (wrong)**
- Finds the bin, and executes correctly.
