### PR TITLE
Fix race condition between updateProcessEnv and getPythonEnvironment

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
   "package-deps": [
     "linter:2.0.0"
   ],
+  "activationHooks": [
+    "core:loaded-shell-environment"
+  ],
   "providedServices": {
     "linter": {
       "versions": {


### PR DESCRIPTION
Atom's updateProcessEnv function modifies process.env, which can
cause the PATH modifications in getPythonEnvironment to be lost.
This can lead to ModuleNotFoundErrors because isort is no longer
in the PATH.

References:
 https://github.com/atom/atom/blob/v1.49.0/src/update-process-env.js#L13
 https://github.com/lexicalunit/atom-isort/blob/v3.2.0/lib/index.js#L3
 https://0xstubs.org/modifying-environment-variables-in-the-atom-editor/

Closes #26